### PR TITLE
Wording correction in the readme: promo -> batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The base URL of the API is `https://wagon-chat.herokuapp.com/`. Feel free to tes
 
 #### Get messages `GET '/:channel/messages'`
 
-Will get you the JSON file of all messages at the promo `:channel`. E.g:
+Will get you the JSON file of all messages for the batch `:channel`. E.g:
 
 ```json
 {


### PR DESCRIPTION
Students of different batches reported me they didn't understand the word "promo".
It might be an English term, but it seems not to be used a lot (at least not in US English, said one of our US students!).
It confuses a lot of students, and I propose to change it to "batch.