### PR TITLE
Add 422 status to validation fail of creates

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -15,7 +15,7 @@ class CommentsController < ApplicationController
     if @comment.save
       render json: @comment
     else
-      render json: { error: @comment.errors }
+      render json: { error: @comment.errors }, status: 422
     end
   end
 


### PR DESCRIPTION
I just noticed a student struggling with this challenge for the following reason. They sent the following as the body:
```json
{ "message": "Hello", "author": "Me" }
``` 

It's not a valid comment since it's lacking the content param. The student was looking at the network tab of the browse tho and saw this tho:
![image](https://user-images.githubusercontent.com/1820441/184027579-0e929872-bec0-4d60-b91d-f78b9cdd1314.png)

Even tho, the request itself was returning an error. This should give the error the correct status.